### PR TITLE
DB Connection prematurely closes during Application init

### DIFF
--- a/app/models/Application.scala
+++ b/app/models/Application.scala
@@ -44,7 +44,7 @@ class Application @javax.inject.Inject() (
   if (Application.initialized) {
     log.info("Skipping initialization after failure.")
   } else {
-    start()
+    start().failed.foreach(t => log.error(s"Start error:", t))
   }
 
   val supervisor = actorSystem.actorOf(Props(classOf[ActorSupervisor], this), "supervisor")

--- a/app/services/database/MasterDdl.scala
+++ b/app/services/database/MasterDdl.scala
@@ -59,7 +59,7 @@ object MasterDdl extends Logging {
             val statement = DdlStatement(sql._1)
             Await.result(SystemDatabase.execute(statement, Some(conn))(txTd), 5.seconds)
           }
-          SystemDatabase.execute(DdlQueries.insert(f)).map(_ => f)
+          SystemDatabase.execute(DdlQueries.insert(f), Some(conn)).map(_ => f)
         }
         Await.result(tx, 30.seconds)
       }


### PR DESCRIPTION
- Fix premature closing of a DB connection using a "dispose" pattern for connection lifetime management.

- Add logging to the "discarded" Future during Application init. Without this it was not obvious why the previous problem was happening.